### PR TITLE
feat: add Windows support via .cmd file

### DIFF
--- a/bin/run.cmd
+++ b/bin/run.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0\run" %*

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.9.0",
   "description": "A CLI tool to install and manage MCP servers.",
   "bin": {
-    "install-mcp": "./bin/run"
+    "install-mcp": "./bin/run",
+    "install-mcp.cmd": "./bin/run.cmd"
   },
   "directories": {
     "lib": "src",


### PR DESCRIPTION
This PR was created by a Graphite background agent: https://app.graphite.com/background-agents/supermemoryai/install-mcp/task/bgt_01k9fstk9af5mvwq3kc9cb1hht

  > This does not quite work on powershell right now. can you find out why?