### PR TITLE
fix: Update VSCode to use dedicated MCP configuration file

### DIFF
--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -111,9 +111,9 @@ function getClientPaths(): { [key: string]: ClientInstallTarget } {
     },
     vscode: {
       type: 'file',
-      path: path.join(baseDir, vscodePath, 'settings.json'),
-      localPath: path.join(process.cwd(), '.vscode', 'settings.json'),
-      configKey: 'mcp.servers',
+      path: path.join(baseDir, vscodePath, 'mcp.json'),
+      localPath: path.join(process.cwd(), '.vscode', 'mcp.json'),
+      configKey: 'mcpServers',
     },
     'claude-code': {
       type: 'file',


### PR DESCRIPTION
Fixes #29

VSCode now expects MCP servers to be configured in a dedicated mcp.json file instead of settings.json. This change updates the installer to use the correct configuration paths:

- Global: ~/.config/Code/User/mcp.json (or platform equivalent)
- Local: .vscode/mcp.json
- Config key: mcpServers (instead of mcp.servers)

This resolves the warning: "MCP servers should no longer be configured in user settings. Use the dedicated MCP configuration instead."