### PR TITLE
Fix biome lint errors in configuration

### DIFF
--- a/bin/run.ts
+++ b/bin/run.ts
@@ -1,4 +1,4 @@
-// biome-ignore lint/style/useImportType: <explanation>
+// biome-ignore lint/style/useImportType: yargs default export is needed for CLI initialization
 import yargs, { ArgumentsCamelCase, Argv } from 'yargs'
 import { config } from 'dotenv'
 import { builder, handler, type InstallArgv } from '../src/commands/install'

--- a/biome.json
+++ b/biome.json
@@ -1,19 +1,14 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "files": {
-    "include": ["**/*.{js,jsx,ts,tsx,json,jsonc}"],
-    "ignore": ["node_modules/**", ".git/**", "dist/**", "coverage/**", "*.lock"]
+    "includes": ["**/*.{js,jsx,ts,tsx,json,jsonc}"]
   },
   "formatter": {
     "enabled": true,
     "lineWidth": 120,
     "lineEnding": "lf",
     "indentStyle": "space",
-    "indentWidth": 2,
-    "quoteStyle": "single"
-  },
-  "organizeImports": {
-    "enabled": true
+    "indentWidth": 2
   },
   "linter": {
     "enabled": true,
@@ -33,19 +28,11 @@
         "noUnusedVariables": "error"
       },
       "suspicious": {
-        "noConsole": "warn",
-        "noConsoleLog": "warn"
+        "noConsole": "warn"
       }
     }
   },
   "javascript": {
-    "formatter": {
-      "semicolons": "asNeeded",
-      "trailingCommas": "es5",
-      "quoteProperties": "asNeeded"
-    }
-  },
-  "typescript": {
     "formatter": {
       "semicolons": "asNeeded",
       "trailingCommas": "es5",

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -11,6 +11,7 @@ import { logger, verbose } from './logger'
 
 export interface ClientConfig {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // biome-ignore lint/suspicious/noExplicitAny: ClientConfig must be flexible to support any client configuration structure
   [key: string]: any
 }
 
@@ -211,7 +212,8 @@ export function getNestedValue(obj: ClientConfig, path: string): ClientConfig | 
 // Helper function to set nested value in an object using dot notation
 export function setNestedValue(obj: ClientConfig, path: string, value: ClientConfig): void {
   const keys = path.split('.')
-  const lastKey = keys.pop()!
+  const lastKey = keys.pop()
+  if (!lastKey) return
   const target = keys.reduce((current, key) => {
     if (!current[key]) current[key] = {}
     return current[key]
@@ -383,8 +385,8 @@ function writeConfigFile(config: ClientConfig, target: ClientFileTarget): void {
     // For .jsonc files, try to preserve comments and formatting using jsonc-parser
     try {
       // Apply modifications to preserve existing structure
-      let editedContent = originalFileContent
-      const modifications: jsonc.Edit[] = []
+      const editedContent = originalFileContent
+      const modifications: Array<jsonc.Edit> = []
 
       // Generate edit operations for each key in the merged config
       for (const key of Object.keys(mergedConfig)) {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -10,7 +10,7 @@ import {
   setNestedValue,
   type ClientConfig,
 } from '../client-config'
-import { spawn } from 'child_process'
+import { spawn } from 'node:child_process'
 
 // Helper to set a server config in a nested structure
 function setServerConfig(
@@ -100,10 +100,10 @@ export interface InstallArgv {
   client: string
   local?: boolean
   yes?: boolean
-  header?: string[]
+  header?: Array<string>
   oauth?: 'yes' | 'no'
   project?: string
-  env?: string[]
+  env?: Array<string>
 }
 
 export const command = '$0 [target]'
@@ -179,10 +179,10 @@ function inferNameFromInput(input: string): string {
       // Skip flags like -y and get the package name
       const packageIndex = parts.findIndex((part, index) => index > 0 && !part.startsWith('-'))
       if (packageIndex !== -1) {
-        return parts[packageIndex]!
+        return parts[packageIndex] || 'server'
       }
     }
-    return parts[0]!
+    return parts[0] || 'server'
   } else {
     // Simple package name like "mcp-server" or "@org/mcp-server"
     return input
@@ -210,7 +210,7 @@ function isSupermemoryUrl(input: string): boolean {
 }
 
 // Parse environment variables from array format into key-value object
-function parseEnvVars(envArray?: string[]): { [key: string]: string } | undefined {
+function parseEnvVars(envArray?: Array<string>): { [key: string]: string } | undefined {
   if (!envArray || envArray.length === 0) {
     return undefined
   }
@@ -288,7 +288,7 @@ export async function handler(argv: ArgumentsCamelCase<InstallArgv>) {
     logger.log('  Please copy the following configuration object and add it to your Warp MCP config:\n')
 
     // Build args array for Warp
-    let warpArgs: string[]
+    let warpArgs: Array<string>
     if (isUrl(target)) {
       warpArgs = ['-y', 'mcp-remote@latest', target]
       // Add headers as arguments for supergateway
@@ -319,7 +319,7 @@ export async function handler(argv: ArgumentsCamelCase<InstallArgv>) {
         2,
       )
         .split('\n')
-        .map((line) => green('  ' + line))
+        .map((line) => green(`  ${line}`))
         .join('\n'),
     )
     logger.box("Read Warp's documentation at", blue('https://docs.warp.dev/knowledge-and-collaboration/mcp'))

--- a/src/detect-transport.ts
+++ b/src/detect-transport.ts
@@ -171,14 +171,15 @@ async function readFirstSseEvent(res: Response, timeoutMs: number): Promise<Firs
       buf += decoder.decode(value, { stream: true })
 
       // SSE frames are separated by a blank line.
-      let idx: number
-      while ((idx = buf.indexOf('\n\n')) !== -1) {
+      let idx = buf.indexOf('\n\n')
+      while (idx !== -1) {
         const frame = buf.slice(0, idx)
         buf = buf.slice(idx + 2)
+        idx = buf.indexOf('\n\n')
 
         // Parse single SSE frame.
         const lines = frame.split(/\r?\n/)
-        const dataLines: string[] = []
+        const dataLines: Array<string> = []
         for (const line of lines) {
           if (line.startsWith(':')) continue // comment
           const colon = line.indexOf(':')


### PR DESCRIPTION
- Update biome.json schema version to 2.3.11
- Fix biome.json configuration (include -> includes, remove invalid keys)
- Add node: protocol to child_process import
- Replace string concatenation with template literals
- Fix biome-ignore comment placeholders
- Add biome-ignore for intentional any type usage
- Remove non-null assertions with proper null checks
- Change let to const where appropriate
- Convert T[] array syntax to Array<T> for consistency
- Refactor assignment in while expression to separate statements