### PR TITLE
feat: add nanobot client support

### DIFF
--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -128,6 +128,12 @@ function getClientPaths(): { [key: string]: ClientInstallTarget } {
       localPath: path.join(process.cwd(), ".mcp.json"),
       configKey: "mcpServers",
     },
+    nanobot: {
+      type: "file",
+      path: path.join(homeDir, ".nanobot", "config.json"),
+      localPath: path.join(process.cwd(), ".nanobot", "config.json"),
+      configKey: "mcp.servers",
+    },
     goose: {
       type: "file",
       path: path.join(homeDir, ".config", "goose", "config.yaml"),
@@ -185,6 +191,7 @@ export const clientNames = [
   "zed",
   "droid",
   "warp",
+  "nanobot",
   // Desktop apps
   "claude-desktop",
   "windsurf",


### PR DESCRIPTION
This PR adds support for [nanobot](https://github.com/HKUDS/nanobot), a popular open-source AI agent framework.

`nanobot` uses MCP servers to extend its capabilities (via the `mcp` tool). Its configuration is stored in `~/.nanobot/config.json` (or locally in `.nanobot/config.json`), and the MCP servers are defined under the `mcp.servers` key.

This addition allows users to easily install MCP servers directly into their nanobot workspace using `npx install-mcp`.

**Changes:**
- Added `nanobot` to the list of supported clients in `clientNames`.
- Configured the correct paths (`~/.nanobot/config.json`) and config key (`mcp.servers`) in `getClientPaths()`.