### PR TITLE
feat: add kilocode client support

### DIFF
--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -128,6 +128,12 @@ function getClientPaths(): { [key: string]: ClientInstallTarget } {
       localPath: path.join(process.cwd(), ".mcp.json"),
       configKey: "mcpServers",
     },
+    kilocode: {
+      type: "file",
+      path: path.join(baseDir, vscodePath, "globalStorage", "kilo.kilo-code", "settings", "mcp_settings.json"),
+      localPath: path.join(process.cwd(), ".kilocode", "mcp.json"),
+      configKey: "mcpServers",
+    },
     goose: {
       type: "file",
       path: path.join(homeDir, ".config", "goose", "config.yaml"),
@@ -191,6 +197,7 @@ export const clientNames = [
   // VS Code extensions
   "cline",
   "roo-cline",
+  "kilocode",
   // Other
   "goose",
   "aider",


### PR DESCRIPTION
This PR adds support for [Kilo Code](https://kilo.ai/docs/automate/mcp/using-in-kilo-code), an AI coding assistant.

Kilo Code manages MCP server configurations at two levels:
1. **Global Configuration**: Stored in `mcp_settings.json` (accessible via VS Code settings, typically under `globalStorage/kilo.kilo-code/settings/mcp_settings.json`).
2. **Project-level Configuration**: Defined in a `.kilocode/mcp.json` file within the project's root directory.

The MCP servers are defined under the `mcpServers` key.

**Changes:**
- Added `kilocode` to the list of supported clients in `clientNames` (under VS Code extensions).
- Configured the correct global path, local path (`.kilocode/mcp.json`), and config key (`mcpServers`) in `getClientPaths()`.